### PR TITLE
Package gcloud has moved and renamed to google-cloud

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,10 +11,10 @@ django-gcloud-storage
 .. image:: https://img.shields.io/pypi/format/django-gcloud-storage.svg
     :target: https://pypi.python.org/pypi/django-gcloud-storage
 
-Django storage module implementation for Google Cloud Storage using the gcloud_
+Django storage module implementation for Google Cloud Storage using the google-cloud_
 python module by Google.
 
-.. _gcloud: https://pypi.python.org/pypi/gcloud
+.. _google-cloud: https://pypi.python.org/pypi/google-cloud
 
 Notice: alpha release
 ---------------------
@@ -31,10 +31,11 @@ Install django-gcloud-storage::
     pip install django-gcloud-storage
 
 Create a GCS service account JSON keyfile and a bucket for your application.
-Check the documentation of gcloud-python and Google Cloud Platform for more
+Check the documentation of google-cloud-python and Google Cloud Platform for more
 details:
 
-https://gcloud-python.readthedocs.org/en/latest/gcloud-auth.html
+https://googlecloudplatform.github.io/google-cloud-python/stable/google-cloud-auth.html
+
 https://cloud.google.com/storage/docs/authentication#generating-a-private-key
 
 Update your Django settings and use it like any other Django storage module::

--- a/django_gcloud_storage/__init__.py
+++ b/django_gcloud_storage/__init__.py
@@ -13,10 +13,10 @@ from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_text, smart_str
-from gcloud import _helpers as gcloud_helpers
-from gcloud import storage
-from gcloud.exceptions import NotFound
-from gcloud.storage.bucket import Bucket
+from google.cloud import _helpers as gcloud_helpers
+from google.cloud import storage
+from google.cloud.exceptions import NotFound
+from google.cloud.storage.bucket import Bucket
 
 __version__ = '0.1.0'
 
@@ -68,7 +68,7 @@ class GCloudFile(File):
 
     def __init__(self, blob, maxsize=1000):
         """
-        :type blob: gcloud.storage.blob.Blob
+        :type blob: google.cloud.storage.blob.Blob
         """
         self._dirty = False
         self._tmpfile = SpooledTemporaryFile(
@@ -182,7 +182,7 @@ class DjangoGCloudStorage(Storage):
 
         blob = self.bucket.get_blob(name)
 
-        # gcloud doesn't provide a public method for this
+        # google.cloud doesn't provide a public method for this
         value = blob._properties.get("timeCreated", None)
         if value is not None:
             naive = datetime.datetime.strptime(value, gcloud_helpers._RFC3339_MICROS)

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,12 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "gcloud>=0.8.0",
+        "google-cloud>=0.19.0",
         "django>=1.8"
     ],
     license="BSD",
     zip_safe=False,
-    keywords='django-gcloud-storage gcloud gcs',
+    keywords='django-gcloud-storage gcloud google-cloud gcs',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def storage_object_for_tests(request, bucket_name=None):
 
     yield storage
 
-    # Manually delete all remaining blobs due to a unicode issue in gcloud
+    # Manually delete all remaining blobs due to a unicode issue in google.cloud
     from django_gcloud_storage import prepare_name
     for blob in storage.bucket.list_blobs():
         storage.bucket.delete_blob(prepare_name(blob.name))

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -5,7 +5,7 @@ import datetime
 import ssl
 from tempfile import TemporaryFile
 
-import gcloud.exceptions
+import google.cloud.exceptions
 import pytest
 from django.core.exceptions import SuspiciousFileOperation
 from django.utils import six
@@ -172,7 +172,7 @@ class TestGCloudStorageClass:
         self.upload_test_file(storage, self.TEST_FILE_NAME, self.TEST_FILE_CONTENT)
         storage.delete(self.TEST_FILE_NAME)
 
-        # Should not raise an exception by gcloud
+        # Should not raise an exception by google.cloud
         assert storage.delete("missing_file") is None
 
     def test_exists_method(self, storage):


### PR DESCRIPTION
Package gcloud has moved and has been renamed to google-cloud on PyPI.
This commit is a simple rename of requirements, imports and links, not tested, but I think there are no breaking changes.