### PR TITLE
Add setting to locally generate unsigned urls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,15 @@ Caveats
 * Everytime a file is opened via the storage module, it will be downloaded again
 * (development) Most tests need access to Google Cloud Storage
 
+Unsigned URLS
+-------
+
+The module generates signed urls by default. This requires calls to storage API which might take some time if you need to return several images at a time. You can generate unsigned urls using the following setting::
+
+  GCS_USE_UNSIGNED_URLS = True
+
+Keep in mind you might need to set the default object permission to public for the unsigned urls to work.  
+
 Contributing
 ------------
 

--- a/django_gcloud_storage/__init__.py
+++ b/django_gcloud_storage/__init__.py
@@ -132,8 +132,6 @@ class DjangoGCloudStorage(Storage):
             self.use_unsigned_urls = use_unsigned_urls
         else:
             self.use_unsigned_urls = getattr(settings, "GCS_USE_UNSIGNED_URLS", False)
-        if self.use_unsigned_urls:
-          import pdb;pdb.set_trace()
 
         self.bucket_subdir = ''  # TODO should be a parameter
 

--- a/django_gcloud_storage/__init__.py
+++ b/django_gcloud_storage/__init__.py
@@ -107,7 +107,7 @@ class GCloudFile(File):
 @deconstructible
 class DjangoGCloudStorage(Storage):
 
-    def __init__(self, project=None, bucket=None, credentials_file_path=None, unsigned_urls=None):
+    def __init__(self, project=None, bucket=None, credentials_file_path=None, use_unsigned_urls=None):
         self._client = None
         self._bucket = None
 
@@ -128,10 +128,12 @@ class DjangoGCloudStorage(Storage):
         else:
             self.project_name = settings.GCS_PROJECT
 
-        if unsigned_urls is not None:
-            self.unsigned_urls = unsigned_urls
+        if use_unsigned_urls is not None:
+            self.use_unsigned_urls = use_unsigned_urls
         else:
-            self.unsigned_urls = getattr(settings, "GCS_UNSIGNED_URLS", False)
+            self.use_unsigned_urls = getattr(settings, "GCS_USE_UNSIGNED_URLS", False)
+        if self.use_unsigned_urls:
+          import pdb;pdb.set_trace()
 
         self.bucket_subdir = ''  # TODO should be a parameter
 
@@ -246,7 +248,7 @@ class DjangoGCloudStorage(Storage):
         name = safe_join(self.bucket_subdir, name)
         name = prepare_name(name)
 
-        if self.unsigned_urls:
+        if self.use_unsigned_urls:
           return "https://storage.googleapis.com/{}/{}".format(self.bucket.name, name)
 
         return self.bucket.get_blob(name).generate_signed_url(expiration=datetime.datetime.now() + datetime.timedelta(hours=1))

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -10,6 +10,7 @@ import pytest
 from django.core.exceptions import SuspiciousFileOperation
 from django.utils import six
 from django.utils.crypto import get_random_string
+from django.test import override_settings
 
 from django_gcloud_storage import safe_join, remove_prefix, GCloudFile
 
@@ -239,3 +240,10 @@ class TestGCloudStorageClass:
 
         assert storage.open(self.TEST_FILE_NAME).read() == self.TEST_FILE_CONTENT
         assert storage.modified_time(self.TEST_FILE_NAME) != first_modified_time
+
+    @override_settings(GCS_USE_UNSIGNED_URLS=True)
+    def test_use_unsigned_urls_option(self, storage):
+        self.upload_test_file(storage, self.TEST_FILE_NAME, self.TEST_FILE_CONTENT)
+        url = storage.url(self.TEST_FILE_NAME)
+        for i in ["Signature=", "GoogleAccessId=", "Expires="]:
+          assert i not in url


### PR DESCRIPTION
This is necessary if you're returning several results at a time, otherwise the requests to generate a signed url substantially slow down the response.