### PR TITLE
fixes get_modified_time in Django>=1.10.

### DIFF
--- a/django_gcloud_storage/__init__.py
+++ b/django_gcloud_storage/__init__.py
@@ -219,6 +219,10 @@ class DjangoGCloudStorage(Storage):
 
         return blob.updated if blob is not None else None
 
+    def get_modified_time(self, name):
+        # In Django>=1.10, modified_time is deprecated, and modified_time will be removed in Django 2.0.
+        return self.modified_time(name)
+
     def listdir(self, path):
         path = safe_join(self.bucket_subdir, path)
         path = prepare_name(path)

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -168,6 +168,11 @@ class TestGCloudStorageClass:
 
         assert isinstance(storage.modified_time(self.TEST_FILE_NAME), datetime.datetime)
 
+    def test_should_return_modified_time_get_modified_time(self, storage):
+        self.upload_test_file(storage, self.TEST_FILE_NAME, self.TEST_FILE_CONTENT)
+
+        assert isinstance(storage.get_modified_time(self.TEST_FILE_NAME), datetime.datetime)
+
     def test_should_be_able_to_delete_files(self, storage):
         self.upload_test_file(storage, self.TEST_FILE_NAME, self.TEST_FILE_CONTENT)
         storage.delete(self.TEST_FILE_NAME)


### PR DESCRIPTION
In Django>=1.10, raises this error:

```
________________________________________ TestGCloudStorageClass.test_should_return_modified_time_get_modified_time _________________________________________

self = <test_class.TestGCloudStorageClass object at 0x7efe1e1fe9e8>, storage = <django_gcloud_storage.DjangoGCloudStorage object at 0x7efe1e20ed68>

    def test_should_return_modified_time_get_modified_time(self, storage):
        self.upload_test_file(storage, self.TEST_FILE_NAME, self.TEST_FILE_CONTENT)

>       assert isinstance(storage.get_modified_time(self.TEST_FILE_NAME), datetime.datetime)

tests/test_class.py:174:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
venv/lib/python3.6/site-packages/django/core/files/storage.py:231: in get_modified_time
    return _possibly_make_aware(dt)
venv/lib/python3.6/site-packages/django/core/files/storage.py:243: in _possibly_make_aware
    return timezone.make_aware(dt, tz).astimezone(timezone.utc)
venv/lib/python3.6/site-packages/django/utils/timezone.py:285: in make_aware
    return timezone.localize(value, is_dst=is_dst)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <UTC>, dt = datetime.datetime(2017, 5, 20, 18, 36, 4, 833000, tzinfo=<UTC>), is_dst = None

    def localize(self, dt, is_dst=False):
        '''Convert naive time to local time'''
        if dt.tzinfo is not None:
>           raise ValueError('Not naive datetime (tzinfo is already set)')
E           ValueError: Not naive datetime (tzinfo is already set)

venv/lib/python3.6/site-packages/pytz/__init__.py:227: ValueError
```

This PR will fix it.