### PR TITLE
Autodetect mimetype when uploading to bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ build/
 
 # test_app database
 test_app/db.sqlite3
+
+# venv
+.venv

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Contributors
 * Titusz Pan <tp@craft.de>
 * George Pchelkin <george@pchelk.in>
 * Shinya Okano <tokibito@gmail.com>
+* Asbjørn A. Fellinghaug <asbjorn@fellinghaug.com>

--- a/django_gcloud_storage/__init__.py
+++ b/django_gcloud_storage/__init__.py
@@ -19,7 +19,7 @@ from google.cloud import storage
 from google.cloud.exceptions import NotFound
 from google.cloud.storage.bucket import Bucket
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
 DJANGO_17 = django.get_version().startswith('1.7.')
 

--- a/django_gcloud_storage/__init__.py
+++ b/django_gcloud_storage/__init__.py
@@ -5,6 +5,7 @@ import datetime
 import os
 import re
 from tempfile import SpooledTemporaryFile
+import mimetypes
 
 import django
 from django.conf import settings
@@ -162,9 +163,14 @@ class DjangoGCloudStorage(Storage):
 
         # Required for InMemoryUploadedFile objects, as they have no fileno
         total_bytes = None if not hasattr(content, 'size') else content.size
+        content_type = None if not hasattr(content, 'content_type') else content.content_type
+        if content_type is None:
+            _, file_extension = os.path.splitext(name)
+            content_type = mimetypes.types_map.get(file_extension, None)
+
 
         blob = self.bucket.blob(name)
-        blob.upload_from_file(content, size=total_bytes)
+        blob.upload_from_file(content, size=total_bytes, content_type=content_type)
 
         return name
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.3.2
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.2
+current_version = 0.3.1
 commit = True
 tag = True
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -219,3 +219,9 @@ class TestGCloudStorageClass:
         storage.use_unsigned_urls = False
         for i in ["Signature=", "GoogleAccessId=", "Expires="]:
             assert i not in url
+
+    def test_correctly_detect_mimetype(self, storage):
+        file_name = "test.jpg"
+        upload_test_file(storage, file_name, "")
+
+        assert "image/jpeg" == urlopen(storage.url(file_name)).info().get("Content-Type")


### PR DESCRIPTION
Hi.

Added a way to autodetect the mimetype when uploading new files to the bucket. content-type was previously not set so all images for instance was using `Content-Type:application/octet-stream`.