### PR TITLE
#22 Fix django.utils.encoding.force_text and django.conf.urls for Django4 support

### DIFF
--- a/django_gcloud_storage/__init__.py
+++ b/django_gcloud_storage/__init__.py
@@ -14,7 +14,7 @@ from django.core.exceptions import SuspiciousFileOperation
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
-from django.utils.encoding import force_text, smart_str
+from django.utils.encoding import force_str, smart_str
 from google.cloud import _helpers as gcloud_helpers
 from google.cloud import storage
 from google.cloud.exceptions import NotFound
@@ -24,8 +24,8 @@ __version__ = '0.4.0'
 
 
 def safe_join(base, path):
-    base = force_text(base).replace("\\", "/").lstrip("/").rstrip("/") + "/"
-    path = force_text(path).replace("\\", "/").lstrip("/")
+    base = force_str(base).replace("\\", "/").lstrip("/").rstrip("/") + "/"
+    path = force_str(path).replace("\\", "/").lstrip("/")
 
     # Ugh... there must be a better way that I can't think of right now
     if base == "/":

--- a/test_app/app/urls.py
+++ b/test_app/app/urls.py
@@ -13,15 +13,15 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import url
+from django.urls import re_path
 from django.views.generic.base import TemplateView
 
 from test_app.app import views
 
 urlpatterns = [
-    url(r'^upload$', views.TestUploadView.as_view()),
-    url(r'^upload/success',
+    re_path(r'^upload$', views.TestUploadView.as_view()),
+    re_path(r'^upload/success',
         TemplateView.as_view(template_name="success.html"),
         name='upload_success'),
-    url(r'^file/(?P<id>[0-9]+)$', views.file),
+    re_path(r'^file/(?P<id>[0-9]+)$', views.file),
 ]


### PR DESCRIPTION
#22 
I made a few fixes for Django4 support.

Notes:
- replaced `django.utils.encoding.force_text` with `force_str`
- replaced `django.conf.urls` with `django.urls.re_path`
  - since `re_path` is available from Django2.0, this fix is valid for later versions.
- Test passed only for Python, not for PyPy.
  - I couldn't run the tests for pypy due to the error below.
    - pypy is installed locally via apt (Ubuntu).

```python
pypy37-django22 create: /home/vagrant/django-gcloud-storage/.tox/pypy37-django22
ERROR: InterpreterNotFound: pypy3.7
pypy38-django22 create: /home/vagrant/django-gcloud-storage/.tox/pypy38-django22
ERROR: InterpreterNotFound: pypy3.8
```